### PR TITLE
Bugfix Vfs Smb driver top level dirs are not correctly parsed

### DIFF
--- a/lib/Horde/Vfs/Smb.php
+++ b/lib/Horde/Vfs/Smb.php
@@ -406,7 +406,13 @@ class Horde_Vfs_Smb extends Horde_Vfs_Base
         $files = array();
         for ($r = 0; $r < $num_lines; $r++) {
             // Match file listing.
-            if (!preg_match('/^  (.+?) +([A-Z]*) +(\d+)  (\w\w\w \w\w\w [ \d]\d \d\d:\d\d:\d\d \d\d\d\d)$/', $res[$r], $match)) {
+            // One or multiple whitespace
+            // followed by filename
+            // Followed by one or multiple WS
+            // Followed by zero, one or more attribute letters
+            // Followed by one or multiple WS
+            // Followed by possibly more statistics
+            if (!preg_match('/^\s+(.+?)\s+(\w*)\s+(\d+)  (\w\w\w \w\w\w [ \d]\d \d\d:\d\d:\d\d \d\d\d\d)$/', $res[$r], $match)) {
                 continue;
             }
 


### PR DESCRIPTION
When upgrading a system from openSUSE Leap 15.2 to Leap 15.3, Gollem starts giving garbled output for top level dir when using Vfs Smb Backend
Seems like either PHP or the PCRE library has a BC break here.

This bug fix is a conservative approach at modernizing the parsing regex.
Seems like quantification (+) of a literal space character no longer works as expected
Replacing them with the symbolic whitespace class with quantifier \s+ seems to fix this.
Added some comments for readability.

This should be covered by a test suite but no time to build one right now.