### PR TITLE
Backport fix passing null

### DIFF
--- a/lib/Horde/Vfs/Base.php
+++ b/lib/Horde/Vfs/Base.php
@@ -78,7 +78,7 @@ abstract class Horde_Vfs_Base
             'vfs_quotalimit' => -1,
             'vfs_quotaroot' => ''
         ));
-        $this->setParams($params);
+        $this->setParams((array) $params);
     }
 
     /**
@@ -122,7 +122,7 @@ abstract class Horde_Vfs_Base
      */
     public function setParams($params = array())
     {
-        $this->_params = array_merge($this->_params, $params);
+        $this->_params = array_merge($this->_params, (array) $params);
     }
 
     /**

--- a/test/Horde/Vfs/SmbTest.php
+++ b/test/Horde/Vfs/SmbTest.php
@@ -17,7 +17,7 @@ class Horde_Vfs_SmbTest extends Horde_Vfs_TestBase
 {
     public static function setUpBeforeClass()
     {
-        $config = self::getConfig('VFS_FTP_TEST_CONFIG', __DIR__);
+        $config = self::getConfig('VFS_SMB_TEST_CONFIG', __DIR__);
         if ($config && !empty($config['vfs']['smb'])) {
             if (!is_executable($config['vfs']['smb']['smbclient'])) {
                 self::$reason = 'No executable smbclient';
@@ -212,7 +212,7 @@ class Horde_Vfs_SmbTest extends Horde_Vfs_TestBase
         self::$vfs->createFolder('', 'hostspectest');
         self::$vfs->createFolder('hostspectest', 'directory');
         self::$vfs->createFolder('hostspectest/directory', 'subdir');
-        $config = self::getConfig('VFS_FTP_TEST_CONFIG', __DIR__);
+        $config = self::getConfig('VFS_SMB_TEST_CONFIG', __DIR__);
         $config['vfs']['smb']['share'] .= '/hostspectest';
         $vfs = Horde_Vfs::factory('Smb', $config['vfs']['smb']);
         $this->assertEquals(


### PR DESCRIPTION
    Safeguard against non-array input.
    
    This can happen when initializing from conf.php.dist and is harmless in PHP 7.4, but breaking in PHP 8.1