### PR TITLE
Support file names with consecutive spaces on Netware FTP servers

### DIFF
--- a/lib/Horde/Vfs/Ftp.php
+++ b/lib/Horde/Vfs/Ftp.php
@@ -586,10 +586,7 @@ class Horde_Vfs_Ftp extends Horde_Vfs_Base
                     $file['date'] = strtotime('00:00:00 ' . $item[5] . ' ' . $item[4] . ' ' . $item[6]);
                 }
 
-                $file['name'] = $item[7];
-                for ($index = 8, $c = count($item); $index < $c; $index++) {
-                    $file['name'] .= ' ' . $item[$index];
-                }
+                $file['name'] = substr($line, 64);
             } else {
                 /* Handle Windows FTP servers returning DOS-style file
                  * listings. */


### PR DESCRIPTION
The `$item = preg_split('/\s+/', $line);` line loses possible consecutive spaces in file names.

This PR fixes it for Netware FTP servers only, where the file name is last on the line and starts at position 64.
