### PR TITLE
fix(vfs): quote smbclient arguments to prevent command injection (CVE-2026-60102)

### DIFF
--- a/lib/Horde/Vfs/Smb.php
+++ b/lib/Horde/Vfs/Smb.php
@@ -142,9 +142,8 @@ class Horde_Vfs_Smb extends Horde_Vfs_Base
 
         $this->_createRoot();
 
-        [$npath, $name] = $this->_escapeShellCommand($this->_getNativePath($path), $name);
-        $cmd = ['get \"' . $name . '\" ' . $localFile];
-        $this->_command($npath, $cmd);
+        $cmd = ['get ' . $this->_quoteSmbArg($name) . ' ' . $this->_quoteSmbArg($localFile)];
+        $this->_command($this->_getNativePath($path), $cmd);
         if (!file_exists($localFile)) {
             throw new Horde_Vfs_Exception(sprintf('Unable to open VFS file "%s".', $this->_getPath($path, $name)));
         }
@@ -188,14 +187,13 @@ class Horde_Vfs_Smb extends Horde_Vfs_Base
         // Double quotes not allowed in SMB filename.
         $name = str_replace('"', "'", $name);
 
-        [$npath, $name] = $this->_escapeShellCommand($this->_getNativePath($path), $name);
-        $cmd = ['put \"' . $tmpFile . '\" \"' . $name . '\"'];
+        $cmd = ['put ' . $this->_quoteSmbArg($tmpFile) . ' ' . $this->_quoteSmbArg($name)];
         // do we need to first autocreate the directory?
         if ($autocreate) {
             $this->autocreatePath($path);
         }
 
-        $this->_command($npath, $cmd);
+        $this->_command($this->_getNativePath($path), $cmd);
     }
 
     /**
@@ -237,9 +235,8 @@ class Horde_Vfs_Smb extends Horde_Vfs_Base
     {
         $this->_createRoot();
 
-        [$path, $name] = $this->_escapeShellCommand($this->_getNativePath($path), $name);
-        $cmd = ['del \"' . $name . '\"'];
-        $this->_command($path, $cmd);
+        $cmd = ['del ' . $this->_quoteSmbArg($name)];
+        $this->_command($this->_getNativePath($path), $cmd);
     }
 
     /**
@@ -254,9 +251,8 @@ class Horde_Vfs_Smb extends Horde_Vfs_Base
     {
         $this->_createRoot();
 
-        [$path, $name] = $this->_escapeShellCommand($this->_getNativePath($path), $name);
         try {
-            $this->_command($this->_getPath($path, $name), ['quit']);
+            $this->_command($this->_getNativePath($this->_getPath($path, $name)), ['quit']);
             return true;
         } catch (Horde_Vfs_Exception $e) {
             return false;
@@ -295,11 +291,10 @@ class Horde_Vfs_Smb extends Horde_Vfs_Base
         }
 
         // Really delete the folder.
-        [$npath, $name] = $this->_escapeShellCommand($this->_getNativePath($path), $name);
-        $cmd = ['rmdir \"' . $name . '\"'];
+        $cmd = ['rmdir ' . $this->_quoteSmbArg($name)];
 
         try {
-            $this->_command($npath, $cmd);
+            $this->_command($this->_getNativePath($path), $cmd);
         } catch (Horde_Vfs_Exception $e) {
             throw new Horde_Vfs_Exception(sprintf('Unable to delete VFS folder "%s".', $this->_getPath($path, $name)));
         }
@@ -338,13 +333,10 @@ class Horde_Vfs_Smb extends Horde_Vfs_Base
             $newpath .= '/';
         }
 
-        [$file, $name] = $this->_escapeShellCommand($oldname, $newname);
+        $oldFull = str_replace('/', '\\', $this->_getNativePath($oldpath)) . $oldname;
+        $newFull = str_replace('/', '\\', $this->_getNativePath($newpath)) . $newname;
         $cmd = [
-            'rename \"'
-            . str_replace('/', '\\\\', $this->_getNativePath($oldpath))
-            . $file . '\" \"'
-            . str_replace('/', '\\\\', $this->_getNativePath($newpath))
-            . $name . '\"',
+            'rename ' . $this->_quoteSmbArg($oldFull) . ' ' . $this->_quoteSmbArg($newFull),
         ];
 
         try {
@@ -369,11 +361,10 @@ class Horde_Vfs_Smb extends Horde_Vfs_Base
         // Double quotes not allowed in SMB filename.
         $name = str_replace('"', "'", $name);
 
-        [$dir, $mkdir] = $this->_escapeShellCommand($this->_getNativePath($path), $name);
-        $cmd = ['mkdir \"' . $mkdir . '\"'];
+        $cmd = ['mkdir ' . $this->_quoteSmbArg($name)];
 
         try {
-            $this->_command($dir, $cmd);
+            $this->_command($this->_getNativePath($path), $cmd);
         } catch (Horde_Vfs_Exception $e) {
             throw new Horde_Vfs_Exception(sprintf('Unable to create VFS folder "%s".', $this->_getPath($path, $name)));
         }
@@ -400,9 +391,8 @@ class Horde_Vfs_Smb extends Horde_Vfs_Base
         $recursive = false
     ) {
         $this->_createRoot();
-        [$path] = $this->_escapeShellCommand($this->_getNativePath($path));
         return $this->parseListing(
-            $this->_command($path, ['ls']),
+            $this->_command($this->_getNativePath($path), ['ls']),
             $filter,
             $dotfiles,
             $dironly
@@ -570,36 +560,60 @@ class Horde_Vfs_Smb extends Horde_Vfs_Base
     }
 
     /**
-     * Replacement for escapeshellcmd(), variable length args, as we only want
-     * certain characters escaped.
+     * Quotes a value for use inside smbclient's -c mini-language.
      *
-     * @param array $array  Strings to escape.
+     * smbclient parses its -c argument itself. Inside that mini-language,
+     * "..." delimits string tokens and ';' separates statements. Everything
+     * that reaches this method is placed inside an argv element handed to
+     * proc_open(), so no shell is involved and shell metacharacters like
+     * $, backtick, |, & carry no meaning. We only have to defuse the
+     * characters that smbclient's own parser cares about, plus reject
+     * control bytes that smbclient can't represent in a filename anyway.
      *
-     * @return array  TODO
+     * @param string $value  Untrusted string to quote.
+     *
+     * @return string  Quoted token safe to concatenate into a smbclient
+     *                 command line.
+     * @throws Horde_Vfs_Exception  If the value contains NUL, CR or LF.
      */
-    protected function _escapeShellCommand()
+    protected function _quoteSmbArg($value)
     {
-        $ret = [];
-        $args = func_get_args();
-        foreach ($args as $arg) {
-            $ret[] = str_replace([';', '\\'], ['\;', '\\\\'], $arg);
+        $value = (string) $value;
+        if (strpbrk($value, "\0\r\n") !== false) {
+            throw new Horde_Vfs_Exception(
+                'Filename contains illegal control character (NUL, CR or LF).'
+            );
         }
-        return $ret;
+        return '"' . str_replace(['\\', '"'], ['\\\\', '\\"'], $value) . '"';
     }
 
     /**
-     * Executes a command and returns output lines in array.
+     * Executes an already-tokenised smbclient command line and returns the
+     * output lines.
      *
-     * @param string $cmd  Command to be executed.
+     * @param array $argv  argv-style array; index 0 is the smbclient binary
+     *                     path, remaining elements are its arguments. Handed
+     *                     directly to proc_open() so no shell is invoked and
+     *                     no argument needs shell-level quoting.
      *
      * @return array  Array on success.
      * @throws Horde_Vfs_Exception
      */
-    protected function _execute($cmd)
+    protected function _execute($argv)
     {
-        $cmd = str_replace('"-U%"', '-N', $cmd);
+        // Anonymous auth: smbclient wants -N instead of -Uempty. Rewrite the
+        // argv element rather than string-patching a shell command line.
+        foreach ($argv as $k => $arg) {
+            if ($arg === '-U') {
+                if (isset($argv[$k + 1]) && $argv[$k + 1] === '') {
+                    array_splice($argv, $k, 2, ['-N']);
+                }
+                break;
+            }
+        }
+
         $proc = proc_open(
-            $cmd,
+            $argv,
             [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
             $pipes
         );
@@ -661,40 +675,51 @@ class Horde_Vfs_Smb extends Horde_Vfs_Base
      * Executes SMB commands - without authentication - and returns output
      * lines in array.
      *
-     * @param array $path  Base path for command.
-     * @param array $cmd   Commands to be executed.
+     * @param string $path  Base path for command. Passed to smbclient's -D
+     *                      as its own argv element, so no quoting is needed.
+     * @param array $cmd    Smbclient-language commands to be executed. Each
+     *                      element is a full smbclient statement (e.g.
+     *                      'put "src" "dst"'). Filenames MUST be pre-quoted
+     *                      by callers with _quoteSmbArg(); this method does
+     *                      not add any escaping of its own to $cmd elements.
+     *                      All statements are joined with ';' and handed to
+     *                      smbclient's -c as a single argv element.
      *
      * @return array  Array on success.
      * @throws Horde_Vfs_Exception
      */
     protected function _command($path, $cmd)
     {
-        [$share] = $this->_escapeShellCommand($this->_params['share']);
-
+        // smbclient reads the password from the PASSWD environment variable.
+        // We set it here (still an intended smbclient auth channel) rather
+        // than embedding the password in argv, where it would be visible
+        // via ps to co-located users.
         putenv('PASSWD=' . $this->_params['password']);
-        $port = isset($this->_params['port'])
-            ? (' "-p' . $this->_params['port'] . '"')
-            : '';
-        $ipoption = isset($this->_params['ipaddress'])
-            ? (' -I ' . $this->_params['ipaddress'])
-            : '';
-        $domain = isset($this->_params['domain'])
-            ? (' -W ' . $this->_params['domain'])
-            : '';
-        $fullcmd = $this->_params['smbclient']
-            . ' "//' . $this->_params['hostspec'] . '/' . $share . '"'
-            . $port
-            . ' "-U' . $this->_params['username'] . '"'
-            . ' -D "' . $path . '"'
-            . $ipoption
-            . $domain
-            . ' -c "';
-        foreach ($cmd as $c) {
-            $fullcmd .= $c . ";";
-        }
-        $fullcmd .= '"';
 
-        return $this->_execute($fullcmd);
+        $argv = [
+            $this->_params['smbclient'],
+            '//' . $this->_params['hostspec'] . '/' . $this->_params['share'],
+        ];
+        if (isset($this->_params['port'])) {
+            $argv[] = '-p';
+            $argv[] = (string) $this->_params['port'];
+        }
+        $argv[] = '-U';
+        $argv[] = (string) $this->_params['username'];
+        $argv[] = '-D';
+        $argv[] = (string) $path;
+        if (isset($this->_params['ipaddress'])) {
+            $argv[] = '-I';
+            $argv[] = (string) $this->_params['ipaddress'];
+        }
+        if (isset($this->_params['domain'])) {
+            $argv[] = '-W';
+            $argv[] = (string) $this->_params['domain'];
+        }
+        $argv[] = '-c';
+        $argv[] = implode(';', $cmd) . ';';
+
+        return $this->_execute($argv);
     }
 
     /**
@@ -727,9 +752,8 @@ class Horde_Vfs_Smb extends Horde_Vfs_Base
                 $this->_command($path . '/' . $dir . '/', []);
             } catch (Horde_Vfs_Exception $e) {
                 try {
-                    $this->_command('/' . $path . '/', ['mkdir \"' . $dir . '\"']);
+                    $this->_command('/' . $path . '/', ['mkdir ' . $this->_quoteSmbArg($dir)]);
                 } catch (Horde_Vfs_Exception $e) {
-                    echo $e;
                     throw new Horde_Vfs_Exception(sprintf('Unable to create VFS root directory "%s".', $this->_params['vfsroot']));
                 }
             }

--- a/test/Unit/SmbCommandInjectionTest.php
+++ b/test/Unit/SmbCommandInjectionTest.php
@@ -1,0 +1,313 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ */
+
+namespace Horde\Vfs\Test\Unit;
+
+use Horde_Vfs_Smb;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression tests for HF-01 — OS command injection through user-controlled
+ * filenames handed to smbclient.
+ *
+ * Reported 2026-07-01 by Matthew Hickey ("Hacker Fantastic"). Root cause:
+ * Horde_Vfs_Smb::_escapeShellCommand() only escaped ';' and '\\' before
+ * concatenating filenames into a shell command that was run through /bin/sh
+ * by proc_open(). Shell metacharacters $(...), backtick, ", newline, |, &
+ * survived and executed as commands.
+ *
+ * The reproducer uses two independent oracles:
+ *
+ *   1. Structural — capture the value that _command() would hand to
+ *      proc_open(). After the fix this must be an argv-style array (proc_open
+ *      then calls execvp() and no shell is involved). Before the fix it is a
+ *      single string containing the raw filename.
+ *
+ *   2. Behavioural — mirror the reporter's PoC harness. Point 'smbclient' at
+ *      /bin/echo and let _command() actually run. If a shell parses the
+ *      command, $(touch <marker>) inside a filename creates the marker file;
+ *      argv-based proc_open() does not.
+ *
+ * Both oracles must hold on every public method that names a file or folder.
+ */
+#[CoversClass(Horde_Vfs_Smb::class)]
+class SmbCommandInjectionTest extends TestCase
+{
+    /**
+     * A payload built to be dangerous only when interpreted by /bin/sh.
+     * $(touch <marker>) inside double quotes executes command substitution
+     * before smbclient (or echo) ever sees the argument. Backtick would do
+     * the same; we pick $(...) because the reporter's PoC used the same
+     * form and because bash and dash both honour it.
+     */
+    private function payloadCreating(string $marker): string
+    {
+        return 'safe$(touch ' . $marker . ').txt';
+    }
+
+    private function makeMarkerPath(string $tag): string
+    {
+        return sys_get_temp_dir() . '/hf01_' . $tag . '_' . bin2hex(random_bytes(6));
+    }
+
+    /**
+     * Concrete subclass that intercepts _execute() and remembers what
+     * _command() built. Nothing is actually run.
+     */
+    private function newCaptureVfs(): CapturingSmb
+    {
+        return new CapturingSmb([
+            'username'  => 'user',
+            'password'  => 'pw',
+            'hostspec'  => 'host',
+            'share'     => 'share',
+            'smbclient' => '/bin/echo',
+            'vfsroot'   => '/vfs',
+        ]);
+    }
+
+    /**
+     * Concrete subclass that actually runs _execute() but points smbclient
+     * at /bin/echo so no SMB server is required. This is the reporter's
+     * PoC pattern packaged as a unit test.
+     */
+    private function newRealisticVfs(): RealisticSmb
+    {
+        return new RealisticSmb([
+            'username'  => 'user',
+            'password'  => 'pw',
+            'hostspec'  => 'host',
+            'share'     => 'share',
+            'smbclient' => '/bin/echo',
+            'vfsroot'   => '/vfs',
+        ]);
+    }
+
+    /**
+     * @return array<string, array{0: callable(Horde_Vfs_Smb, string): void}>
+     *
+     * Each row is (label, driver-callable) where driver-callable takes the
+     * vfs instance and the attacker-controlled filename and performs the
+     * VFS operation. Every mutating/reading method that assembles a
+     * smbclient command must be covered.
+     */
+    public static function attackSurfaces(): array
+    {
+        return [
+            'createFolder'  => [static fn ($vfs, $name) => $vfs->createFolder('', $name)],
+            'deleteFile'    => [static fn ($vfs, $name) => $vfs->deleteFile('', $name)],
+            'rename'        => [static fn ($vfs, $name) => $vfs->rename('', 'old', '', $name)],
+            'readFile'      => [static fn ($vfs, $name) => @$vfs->readFile('', $name)],
+            'write'         => [static function ($vfs, $name): void {
+                $tmp = tempnam(sys_get_temp_dir(), 'hf01_src');
+                try {
+                    $vfs->write('', $name, $tmp);
+                } finally {
+                    @unlink($tmp);
+                }
+            }],
+            'isFolder'      => [static fn ($vfs, $name) => $vfs->isFolder('', $name)],
+            'listFolderPath' => [static fn ($vfs, $name) => @$vfs->listFolder($name)],
+        ];
+    }
+
+    /**
+     * Structural oracle: after the fix, _execute() must be handed an argv
+     * array. Every element is a separate argument, so the attacker payload
+     * never enters a shell parse. Before the fix, it is a single string and
+     * this assertion fails.
+     *
+     * We rebuild rootCreated to skip the _createRoot() dance for methods
+     * that would otherwise fire extra _command() calls (the last-call check
+     * inspects only the operation under test).
+     */
+    #[DataProvider('attackSurfaces')]
+    public function testCommandArgumentIsArgvArray(callable $driver): void
+    {
+        $vfs = $this->newCaptureVfs();
+        $driver($vfs, 'safe.txt');
+
+        $last = $vfs->lastExecuteArg;
+        $this->assertNotNull($last, 'operation did not invoke _execute()');
+        $this->assertIsArray(
+            $last,
+            'HF-01: _command() handed a shell string to proc_open() — must be an argv array so no /bin/sh is invoked'
+        );
+        // Sanity: the first element must be the smbclient binary itself,
+        // not shell arguments, quoting, or a concatenated command.
+        $this->assertSame('/bin/echo', $last[0], 'argv[0] must be the smbclient binary');
+    }
+
+    /**
+     * Behavioural oracle — the reporter's PoC as an assertion.
+     *
+     * Point smbclient at /bin/echo. If any layer between us and execve()
+     * hands the payload to /bin/sh, $(touch <marker>) creates the marker
+     * file. If everything uses argv-style exec, the marker does not appear.
+     */
+    #[DataProvider('attackSurfaces')]
+    public function testFilenamePayloadDoesNotFireCommandSubstitution(callable $driver): void
+    {
+        $marker = $this->makeMarkerPath('cmdsubst');
+        try {
+            $vfs = $this->newRealisticVfs();
+            try {
+                $driver($vfs, $this->payloadCreating($marker));
+            } catch (\Throwable $e) {
+                // We do not care if the VFS operation reports failure — echo
+                // is not smbclient, so the parseListing/exit-code path will
+                // often throw. We only care whether the payload fired.
+            }
+
+            $this->assertFileDoesNotExist(
+                $marker,
+                'HF-01: $(touch ...) in a filename executed — command substitution reached /bin/sh'
+            );
+        } finally {
+            @unlink($marker);
+        }
+    }
+
+    /**
+     * Same behavioural check for backtick command substitution, which the
+     * reporter's original disclosure highlighted alongside $(...).
+     */
+    #[DataProvider('attackSurfaces')]
+    public function testBacktickPayloadDoesNotFireCommandSubstitution(callable $driver): void
+    {
+        $marker = $this->makeMarkerPath('backtick');
+        try {
+            $vfs = $this->newRealisticVfs();
+            try {
+                $driver($vfs, 'safe`touch ' . $marker . '`.txt');
+            } catch (\Throwable $e) {
+                // ignore — see above
+            }
+
+            $this->assertFileDoesNotExist(
+                $marker,
+                'HF-01: `touch ...` in a filename executed — backtick command substitution reached /bin/sh'
+            );
+        } finally {
+            @unlink($marker);
+        }
+    }
+
+    /**
+     * Newline in a filename must not let the attacker chain a second shell
+     * command onto the smbclient invocation.
+     */
+    #[DataProvider('attackSurfaces')]
+    public function testNewlinePayloadDoesNotChainCommands(callable $driver): void
+    {
+        $marker = $this->makeMarkerPath('newline');
+        try {
+            $vfs = $this->newRealisticVfs();
+            try {
+                $driver($vfs, "safe.txt\ntouch " . $marker);
+            } catch (\Throwable $e) {
+                // ignore
+            }
+
+            $this->assertFileDoesNotExist(
+                $marker,
+                'HF-01: newline in filename let attacker chain a second shell command'
+            );
+        } finally {
+            @unlink($marker);
+        }
+    }
+
+    /**
+     * Config-derived interpolations. The reporter's write-up covers only
+     * the request-derived filename sink, but the same shell-string
+     * assembly interpolates $hostspec, $username, $ipaddress, $domain,
+     * $port and $share without escaping. A hostile or careless
+     * conf.php should not turn into RCE.
+     */
+    public function testHostspecFromConfigDoesNotFireCommandSubstitution(): void
+    {
+        $marker = $this->makeMarkerPath('hostspec');
+        try {
+            $vfs = new RealisticSmb([
+                'username'  => 'user',
+                'password'  => 'pw',
+                'hostspec'  => 'host$(touch ' . $marker . ')',
+                'share'     => 'share',
+                'smbclient' => '/bin/echo',
+                'vfsroot'   => '/vfs',
+            ]);
+            try {
+                $vfs->createFolder('', 'safe');
+            } catch (\Throwable $e) {
+                // ignore
+            }
+
+            $this->assertFileDoesNotExist(
+                $marker,
+                'HF-01: hostspec config value reached /bin/sh — RCE via conf.php'
+            );
+        } finally {
+            @unlink($marker);
+        }
+    }
+}
+
+/**
+ * Capturing subclass — records the argument _execute() would receive and
+ * returns a plausible smbclient success response so the caller can
+ * continue.
+ */
+class CapturingSmb extends Horde_Vfs_Smb
+{
+    /** @var mixed */
+    public $lastExecuteArg = null;
+
+    public function __construct(array $params)
+    {
+        parent::__construct($params);
+        // Skip the vfsroot bootstrap — every operation would otherwise
+        // fire extra _command() calls that overwrite lastExecuteArg with
+        // mkdir noise. The point of this fixture is to inspect the
+        // operation under test, not the root-creation preamble.
+        $this->_rootCreated = true;
+    }
+
+    protected function _execute($cmd)
+    {
+        $this->lastExecuteArg = $cmd;
+        // Return output that satisfies the various post-processing paths:
+        //  - readFile checks that the local temp file exists (we can't
+        //    fake that here — the readFile test tolerates a thrown
+        //    exception, we still capture the arg).
+        //  - listFolder feeds the output through parseListing which is
+        //    happy with an empty array.
+        return [];
+    }
+}
+
+/**
+ * Realistic subclass — leaves _execute() alone so proc_open() actually
+ * runs. smbclient is pointed at /bin/echo in the params so no SMB server
+ * is required. If any layer invokes /bin/sh, the shell parses the
+ * command line and the attacker payload fires; we assert this does not
+ * happen.
+ */
+class RealisticSmb extends Horde_Vfs_Smb
+{
+    public function __construct(array $params)
+    {
+        parent::__construct($params);
+        $this->_rootCreated = true;
+    }
+}


### PR DESCRIPTION
Harden Horde_Vfs_Smb against crafted resource names. It previously only neutralised ';' and '\' but not $(...), backticks, newlines as attack vectors. 

Now proc_open() calls execvp() directly and no shell is involved. Filenames placed inside smbclient's own -c mini-language are quoted by _quoteSmbArg() to escape '\' and '"'. NUL/CR/LF are rejected.

Reported by *Hacker Fantastic*.
CVE assignment coordinated by *vulncheck.com*.